### PR TITLE
add: git in the installed packages of the dashboard VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ How to start it?
 - `ssh` to the machine you just created.
 - Install the pre-requisites:
 ```
-sudo apt-get install python-pip python-dev
+sudo apt-get install python-pip python-dev git
 sudo pip install ansible
 sudo pip install python-novaclient
 ```


### PR DESCRIPTION
On some images (e.g. Ubuntu), `git` won't be present on the system, hence its installation before cloning the repo.
